### PR TITLE
Make tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+option(disable_tests "Skips compiling tests for the library" off)
+
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 
@@ -40,4 +42,6 @@ target_compile_options(jrx-objects PRIVATE "-fPIC")
 target_include_directories(jrx-objects BEFORE PUBLIC include)
 target_include_directories(jrx-objects BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
-add_subdirectory(src/tests)
+if(!disable_tests)
+    add_subdirectory(src/tests)
+endif()


### PR DESCRIPTION
Compiling the library via CMake on MSVC currently fails as Windows has no `unistd.h`.
This can be worked around by making tests optional (how many downstream users care about them anyway?) and opt-in, specifying `-Denable_tests=on` when invoking CMake.