### PR TITLE
Fix use of possibly uninintialized variable.

### DIFF
--- a/src/tests/testregex.c
+++ b/src/tests/testregex.c
@@ -1104,7 +1104,7 @@ static int catchfree(regex_t* preg, int flags, int* tabs, char* spec, char* re, 
 
 int main(int argc, char** argv)
 {
-    int flags;
+    int flags = 0;
     int cflags;
     int eflags;
     int nmatch;


### PR DESCRIPTION
This patch initializes a variable which before was used possibly
uninitialized. This is flagged by e.g., `clang` with `-Wuninitialized`.